### PR TITLE
Getting get_historical to work

### DIFF
--- a/yahoo_finance/__init__.py
+++ b/yahoo_finance/__init__.py
@@ -267,13 +267,10 @@ class Share(Base):
         for s, e in get_date_range(start_date, end_date):
             try:
                 query = self._prepare_query(table='historicaldata', startDate=s, endDate=e)
-                hist.append(self._request(query))
+                hist.extend(self._request(query))
             except TypeError:
                 pass
-        try:
-            return hist[0]
-        except IndexError:
-            return None
+        return hist
 
     def get_info(self):
         """

--- a/yahoo_finance/__init__.py
+++ b/yahoo_finance/__init__.py
@@ -270,6 +270,8 @@ class Share(Base):
                 hist.extend(self._request(query))
             except TypeError:
                 pass
+            except AttributeError:
+                pass
         return hist
 
     def get_info(self):


### PR DESCRIPTION
Now get_historical appears to work correctly.  Test:

```python
from yahoo_finance import Share
share = Share('FB')
hist_data = share.get_historical('2011-01-01','2015-01-01')
len(hist_data)
```