### PR TITLE
Support python 3 syntax and add some tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+
+python:
+    - "2.6"
+    - "2.7"
+    - "pypy"
+    - "pypy3"
+    - "3.3"
+    - "3.4"
+
+install:
+    - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip --quiet install argparse unittest2; fi
+    - python setup.py install
+
+script:
+    -  nosetests --with-coverage --cover-package=yahoo_finance
+
+after_success:
+    - pip install --quiet coveralls
+    - coveralls

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-    ],
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+     ],
 
     # What does your project relate to?
     keywords='stocks market finance yahoo quotes shares currency',

--- a/test/test_yahoo.py
+++ b/test/test_yahoo.py
@@ -1,0 +1,61 @@
+import datetime
+import sys
+import unittest
+
+if sys.version_info < (2, 7):
+    from unittest2 import main as test_main, SkipTest, TestCase
+else:
+    from unittest import main as test_main, SkipTest, TestCase
+
+from yahoo_finance import Currency, Share
+
+
+class TestShare(TestCase):
+    def test_yhoo(self):
+        yahoo = Share("YHOO")
+        # assert that these are float-like
+        float(yahoo.get_open())
+        float(yahoo.get_price())
+
+    #def test_info(self):
+    #    yahoo = Share("YHOO")
+    #    info = yahoo.get_info()
+    #    self.assertEqual(info["Sector"], "Technology")
+
+    def test_historical(self):
+        yahoo = Share("YHOO")
+        historical = yahoo.get_historical("2014-04-25", "2014-04-29")
+        self.assertEqual(len(historical), 3)
+        expected = {
+            'Adj_Close': '35.83',
+            'Close': '35.83',
+            'Date': '2014-04-29',
+            'High': '35.89',
+            'Low': '34.12',
+            'Open': '34.37',
+            'Symbol': 'YHOO',
+            'Volume': '28736000'
+        }
+        self.assertDictEqual(historical[0], expected)
+
+class TestCurrency(TestCase):
+    def test_eurpln(self):
+        eur_pln = Currency("EURPLN")
+        # assert these are float-like
+        float(eur_pln.get_bid())
+        float(eur_pln.get_ask())
+        float(eur_pln.get_rate())
+
+    def test_eurpln_date(self):
+        eur_pln = Currency("EURPLN")
+        try:
+            datetime.datetime.strptime(eur_pln.get_trade_datetime(),
+                                       "%Y-%m-%d %H:%M:%S %Z%z")
+        except ValueError as v:
+            if "bad directive" in str(v):
+                raise SkipTest("datetime format checking requires the %z directive.")
+            else:
+                raise
+
+if __name__ == "__main__":
+    test_main()

--- a/yahoo_finance/__init__.py
+++ b/yahoo_finance/__init__.py
@@ -1,4 +1,4 @@
-import yql
+import yahoo_finance.yql
 
 from datetime import datetime, timedelta
 import pytz
@@ -83,8 +83,8 @@ class Base(object):
         query = 'select * from yahoo.finance.{table} where {key} = "{symbol}"'.format(
             symbol=self.symbol, table=table, key=key)
         if kwargs:
-            for k, v in kwargs.iteritems():
-                query += ' and {0}="{1}"'.format(k, v)
+            query += ''.join(' and {0}="{1}"'.format(k, v)
+                             for k, v in kwargs.items())
         return query
 
     @staticmethod
@@ -107,7 +107,7 @@ class Base(object):
         """
         # check if response is dictionary, skip if it is different e.g. list from `get_historical()`
         if isinstance(results, dict):
-            for k, v in results.iteritems():
+            for k, v in results.items():
                 if v:
                     if 'N/A' in v:
                         results[k] = None
@@ -115,7 +115,7 @@ class Base(object):
     def _request(self, query):
         response = yql.YQLQuery().execute(query)
         try:
-            results = response['query']['results'].itervalues().next()
+            _, results = response['query']['results'].popitem()
         except (KeyError, StopIteration):
             try:
                 raise YQLQueryError(response['error']['description'])

--- a/yahoo_finance/yql.py
+++ b/yahoo_finance/yql.py
@@ -33,7 +33,16 @@ Hosted on GitHub: http://github.com/yahoo/yos-social-python/tree/master
 __author__   = 'Dustin Whittle <dustin@yahoo-inc.com>'
 __version__  = '0.1'
 
-import httplib, urllib, simplejson
+try:
+    from http.client import HTTPConnection
+except ImportError:
+    from httplib import HTTPConnection
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
+import simplejson
 
 # Yahoo! YQL API
 PUBLIC_API_URL  = 'http://query.yahooapis.com/v1/public/yql'
@@ -43,10 +52,10 @@ DATATABLES_URL  = 'store://datatables.org/alltableswithkeys'
 class YQLQuery(object):
 
   def __init__(self):
-    self.connection = httplib.HTTPConnection('query.yahooapis.com')
+    self.connection = HTTPConnection('query.yahooapis.com')
 
   def execute(self, yql, token = None):
 
-    self.connection.request('GET', PUBLIC_API_URL + '?' + urllib.urlencode({ 'q': yql, 'format': 'json', 'env': DATATABLES_URL }))
+    self.connection.request('GET', PUBLIC_API_URL + '?' + urlencode({ 'q': yql, 'format': 'json', 'env': DATATABLES_URL }))
     return simplejson.loads(self.connection.getresponse().read())
 


### PR DESCRIPTION
Adds a .travis.yml and test against several python versions.

*Note: The %z directive is platform dependent before python 3.3.*

See test output here: https://travis-ci.org/hayd/yahoo-finance/builds/59332690 (Note: you need to turn on travis for this repository, see [steps 1 and 2 on the travis docs](http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in).)