### PR TITLE
Avoid unclosed sockets when the application terminated

### DIFF
--- a/yahoo_finance/yql.py
+++ b/yahoo_finance/yql.py
@@ -59,3 +59,5 @@ class YQLQuery(object):
     self.connection.request('GET', PUBLIC_API_URL + '?' + urlencode({ 'q': yql, 'format': 'json', 'env': DATATABLES_URL }))
     return simplejson.loads(self.connection.getresponse().read())
 
+  def __del__(self):
+    self.connection.close()


### PR DESCRIPTION
Got following error message:

ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.1.6', 56145), raddr=('98.137.200.255', 80)>
  response = yql.YQLQuery().execute(query)

