### PR TITLE
Added MultiShare class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,34 @@ Avalible methods
 - ``get_trade_datetime()``
 - ``refresh()``
 
+MultiShare Object
+^^^^^^^^^^^^^^^^^
+
+Useful to bundle Shares and reduce YQL API calls
+
+Example: Yahoo! (YHOO), Microsoft (MSFT) and Tesla (TSLA)
+
+.. code:: python
+
+    >>> from yahoo_finance import MultiShare
+    >>> shares = MultiShare(["YHOO", "MSFT", "TSLA"])
+    >>> shares.get_share()
+    {'YHOO': <yahoo_finance.Share object at 0x10e45a690>, 'TSLA': <yahoo_finance.Share object at 0x10e45aed0>, 'MSFT': <yahoo_finance.Share object at 0x10e45ab10>}
+    >>> shares.get_share('YHOO').get_price()
+    '29.37'
+    >>> shares.add_share('GOOG')
+    >>> shares.get_share()
+    {'GOOG': <yahoo_finance.Share object at 0x10e45a450>, 'YHOO': <yahoo_finance.Share object at 0x10e45a690>, 'TSLA': <yahoo_finance.Share object at 0x10e45aed0>, 'MSFT': <yahoo_finance.Share object at 0x10e45ab10>}
+    >>> shares.get_share('GOOG').get_price()
+    '708.40'
+
+Available methods
+
+- ``get_share()``
+- ``add_share()``
+- ``del_share()``
+- ``refresh()``
+
 Requirements
 ------------
 

--- a/test/test_yahoo.py
+++ b/test/test_yahoo.py
@@ -6,7 +6,7 @@ if sys.version_info < (2, 7):
 else:
     from unittest import main as test_main, SkipTest, TestCase
 
-from yahoo_finance import Currency, Share, edt_to_utc, get_date_range
+from yahoo_finance import Currency, Share, MultiShare, edt_to_utc, get_date_range
 
 
 class TestShare(TestCase):
@@ -105,6 +105,28 @@ class TestCurrency(TestCase):
                 raise SkipTest("datetime format checking requires the %z directive.")
             else:
                 raise
+
+class TestMultiShare(TestCase):
+
+    def setUp(self):
+        self.no_shares = MultiShare()
+        self.multi = MultiShare(["AAPL", "TSLA", "MSFT"])
+
+    def test_get_share(self):
+        keys = sorted(self.multi.get_share().keys())
+        self.assertEqual(keys, ["AAPL", "MSFT", "TSLA"])
+        for share in keys:
+            self.assertNotEqual(None, self.multi.get_share(share).get_open())
+            self.assertNotEqual(None, self.multi.get_share(share).get_price())
+
+    def test_add(self):
+        self.multi.add_share('YHOO')
+        self.assertTrue('YHOO' in self.multi.get_share().keys())
+        self.assertTrue(isinstance(self.multi.get_share('yhoo'), Share))
+
+    def test_del(self):
+        self.multi.del_share('AAPL')
+        self.assertFalse('AAPL' in self.multi.get_share().keys())
 
 if __name__ == "__main__":
     test_main()


### PR DESCRIPTION
This class bundles several Share objects together and will update
them all as a single YQL API request. This is useful for grabbing
data for a large amount of Shares, where you might otherwise start
running into rate limiting issues with the YQL API.

This includes Testcases and README update documenting the new class.