### PR TITLE
Add bid and ask methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,8 @@ Available methods
 - ``get_volume()``
 - ``get_prev_close()``
 - ``get_open()``
+- ``get_bid()``
+- ``get_ask()``
 - ``get_avg_daily_volume()``
 - ``get_stock_exchange()``
 - ``get_market_cap()``

--- a/yahoo_finance/__init__.py
+++ b/yahoo_finance/__init__.py
@@ -189,6 +189,12 @@ class Share(Base):
     def get_change(self):
         return self.data_set['Change']
 
+    def get_ask(self):
+        return self.data_set['Ask']
+
+    def get_bid(self):
+        return self.data_set['Bid']
+
     def get_percent_change(self):
         return self.data_set['PercentChange']
 


### PR DESCRIPTION
I had to work on a project which required `Bid` and `Ask`. Yahoo APIs gives out these values. [See Example](http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20yahoo.finance.quotes%20where%20symbol%20in%20(%27AMDA%27)%20&env=store://datatables.org/alltableswithkeys)

This adds two methods:

- get_bid()
- get_ask()

