### PR TITLE
Update README.rst to use yahoo-finance naming

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 =============
-yhoo-finance
+yahoo-finance
 =============
 
 Python module to get stock data from Yahoo! Finance
@@ -11,7 +11,7 @@ Legal disclaimer
 ----------------
 Yahoo!, Y!Finance, and Yahoo! finance are registered trademarks of Yahoo, Inc.
 
-yhoo-finance is not affiliated, endorsed, or vetted by Yahoo, Inc. It's an open-source tool that uses Yahoo's publicly available APIs, and is intended for research and educational purposes.
+yahoo-finance is not affiliated, endorsed, or vetted by Yahoo, Inc. It's an open-source tool that uses Yahoo's publicly available APIs, and is intended for research and educational purposes.
 
 You should refer to Yahoo!'s terms of use (https://policies.yahoo.com/us/en/yahoo/terms/product-atos/apiforydn/index.htm, https://legal.yahoo.com/us/en/yahoo/terms/otos/index.html, https://policies.yahoo.com/us/en/yahoo/terms/index.htm) for details on your rights to use the actual data downloaded. Remember - the Yahoo! finance API is intended for personal use only.
 
@@ -38,7 +38,7 @@ From development repo (requires git)
 
 .. code:: bash
 
-    $ git clone git://github.com/lukaszbanasiak/yhoo-finance.git
+    $ git clone https://github.com/yahoo-finance/yahoo-finance.git
     $ cd yahoo-finance
     $ python setup.py install
 


### PR DESCRIPTION
Update the code sample to clone the repo.
Change the name from `yhoo-finance `to `yahoo-finance` to match the name of the Python package.

Note: Feel free to discard this PR if the name yhoo-finance must be used due to legal reasons.